### PR TITLE
Fix constant reference to use instance variable prefix

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,7 +69,7 @@ class App(QObject):
 
         # Run / lap state
         self._run_started: bool = False          # True once car crosses start line
-        self._stationary_samples: int = _GARAGE_STATIONARY_SAMPLES  # start as "in garage"
+        self._stationary_samples: int = self._GARAGE_STATIONARY_SAMPLES  # start as "in garage"
         self._persisted_symptoms: dict[SymptomType, Symptom] = {}
 
         self._client = CRESTClient()


### PR DESCRIPTION
## Summary
Fixed a bug where a module-level constant was being referenced instead of the instance variable in the `__init__` method.

## Changes
- Changed `_GARAGE_STATIONARY_SAMPLES` to `self._GARAGE_STATIONARY_SAMPLES` in the initialization of `self._stationary_samples`
  - This ensures the instance variable is properly initialized using the class constant rather than attempting to reference an undefined module-level constant
  - Maintains consistency with the naming convention used throughout the codebase

## Details
This was a simple but important fix that corrects the variable reference pattern. The constant should be accessed as an instance/class attribute using the `self.` prefix to properly initialize the instance variable.

https://claude.ai/code/session_01YH7GjvLC67QPmXHtqUKxQQ